### PR TITLE
Extract core deck logic into reusable `tcg` package and adapt CLI

### DIFF
--- a/cmd/tcgcli/main.go
+++ b/cmd/tcgcli/main.go
@@ -2,16 +2,14 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
-	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"tcgcli/tcg"
 )
 
 const (
@@ -27,56 +25,9 @@ const (
 	colorWhite        = "\033[37m"
 )
 
-const (
-	cardsURL = "https://raw.githubusercontent.com/flibustier/pokemon-tcg-pocket-database/main/dist/cards.json"
-	setsURL  = "https://raw.githubusercontent.com/flibustier/pokemon-tcg-pocket-database/main/dist/sets.json"
-)
-
-type Card struct {
-	Name string `json:"name"`
-	Set  string `json:"set"`
-	ID   string `json:"id"`
-}
-
-type CardEntry struct {
-	Name  string `json:"name"`
-	Set   string `json:"set"`
-	Count int    `json:"count"`
-}
-
-type BattleRecord struct {
-	Date     string `json:"date"`
-	Result   string `json:"result"`
-	Opponent string `json:"opponent"`
-}
-
-type deckFileData struct {
-	Cards         []CardEntry    `json:"cards"`
-	BattleHistory []BattleRecord `json:"battle_history"`
-}
-
-type Deck struct {
-	Name          string
-	FilePath      string
-	Cards         []CardEntry
-	BattleHistory []BattleRecord
-	ValidCards    []Card
-}
-
 type DeckManager struct {
 	DecksDir    string
-	CurrentDeck *Deck
-}
-
-type remoteCard struct {
-	Set    string            `json:"set"`
-	Number json.Number       `json:"number"`
-	Label  map[string]string `json:"label"`
-}
-
-type remoteSet struct {
-	Code  string            `json:"code"`
-	Label map[string]string `json:"label"`
+	CurrentDeck *tcg.Deck
 }
 
 func main() {
@@ -98,30 +49,15 @@ func main() {
 }
 
 func NewDeckManager(decksDir string) (*DeckManager, error) {
-	if err := os.MkdirAll(decksDir, 0o755); err != nil {
-		return nil, err
-	}
 	return &DeckManager{DecksDir: decksDir}, nil
 }
 
 func (m *DeckManager) ListExistingDecks() ([]string, error) {
-	entries, err := os.ReadDir(m.DecksDir)
+	manager, err := tcg.NewDeckManager(m.DecksDir)
 	if err != nil {
 		return nil, err
 	}
-
-	var decks []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		if strings.HasSuffix(name, ".json") {
-			decks = append(decks, strings.TrimSuffix(name, ".json"))
-		}
-	}
-	sort.Strings(decks)
-	return decks, nil
+	return manager.ListExistingDecks()
 }
 
 func (m *DeckManager) CreateNewDeck(reader *bufio.Reader) error {
@@ -134,18 +70,21 @@ func (m *DeckManager) CreateNewDeck(reader *bufio.Reader) error {
 		return nil
 	}
 
-	deckFile := filepath.Join(m.DecksDir, deckName+".json")
-	if _, err := os.Stat(deckFile); err == nil {
+	manager, err := tcg.NewDeckManager(m.DecksDir)
+	if err != nil {
+		return err
+	}
+	deck, err := manager.CreateDeck(deckName)
+	if errors.Is(err, os.ErrExist) {
 		fmt.Printf("%sA deck with that name already exists.%s\n", colorRed, colorReset)
 		return nil
 	}
-
-	deck, err := NewDeck(deckName, deckFile)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("%sNew deck '%s' created.%s\n", colorGreen, deckName, colorReset)
+	m.handleDeckLoadMessages(deck)
 	m.CurrentDeck = deck
 	return nil
 }
@@ -176,13 +115,17 @@ func (m *DeckManager) LoadExistingDeck(reader *bufio.Reader) error {
 	}
 
 	selectedDeck := decks[choice-1]
-	deckFile := filepath.Join(m.DecksDir, selectedDeck+".json")
-	deck, err := NewDeck(selectedDeck, deckFile)
+	manager, err := tcg.NewDeckManager(m.DecksDir)
+	if err != nil {
+		return err
+	}
+	deck, err := manager.LoadDeck(selectedDeck)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("%sDeck '%s' loaded.%s\n", colorGreen, selectedDeck, colorReset)
+	m.handleDeckLoadMessages(deck)
 	m.CurrentDeck = deck
 	return nil
 }
@@ -223,268 +166,7 @@ func (m *DeckManager) SelectDeck(reader *bufio.Reader) error {
 	}
 }
 
-func NewDeck(name, filePath string) (*Deck, error) {
-	deck := &Deck{
-		Name:     name,
-		FilePath: filePath,
-	}
-
-	deck.ValidCards = loadValidCards()
-	if err := deck.loadDeckFile(); err != nil {
-		return nil, err
-	}
-
-	return deck, nil
-}
-
-func (d *Deck) loadDeckFile() error {
-	if _, err := os.Stat(d.FilePath); errors.Is(err, os.ErrNotExist) {
-		fmt.Printf("%sDeck file '%s' not found. Starting new deck '%s'.%s\n", colorYellow, d.FilePath, d.Name, colorReset)
-		d.Cards = []CardEntry{}
-		d.BattleHistory = []BattleRecord{}
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	file, err := os.Open(d.FilePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	var data deckFileData
-	decoder := json.NewDecoder(file)
-	if err := decoder.Decode(&data); err != nil {
-		fmt.Printf("%sError decoding %s. Starting with an empty deck.%s\n", colorRed, d.FilePath, colorReset)
-		d.Cards = []CardEntry{}
-		d.BattleHistory = []BattleRecord{}
-		return nil
-	}
-
-	d.Cards = data.Cards
-	d.BattleHistory = data.BattleHistory
-	fmt.Printf("%sDeck '%s' loaded from %s.%s\n", colorGreen, d.Name, d.FilePath, colorReset)
-	return nil
-}
-
-func (d *Deck) SaveDeck() error {
-	data := deckFileData{
-		Cards:         d.Cards,
-		BattleHistory: d.BattleHistory,
-	}
-
-	if err := os.MkdirAll(filepath.Dir(d.FilePath), 0o755); err != nil {
-		return err
-	}
-
-	file, err := os.Create(d.FilePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(&data); err != nil {
-		return err
-	}
-
-	fmt.Printf("%sDeck '%s' saved successfully!%s\n", colorGreen, d.Name, colorReset)
-	return nil
-}
-
-func (d *Deck) ListAvailableCards() {
-	if len(d.ValidCards) == 0 {
-		fmt.Printf("%sNo valid cards available.%s\n", colorRed, colorReset)
-		return
-	}
-
-	fmt.Printf("%s\nAvailable Cards:%s\n", colorCyan, colorReset)
-	for _, card := range d.ValidCards {
-		fmt.Printf(" - %s (Set: %s, ID: %s)\n", formatForDisplay(card.Name), formatForDisplay(card.Set), card.ID)
-	}
-}
-
-func (d *Deck) SearchCards(term string) []Card {
-	normalized := strings.ToLower(strings.TrimSpace(term))
-	if normalized == "" {
-		return nil
-	}
-
-	var matches []Card
-	for _, card := range d.ValidCards {
-		name := strings.ToLower(card.Name)
-		set := strings.ToLower(card.Set)
-		if strings.Contains(name, normalized) || strings.Contains(set, normalized) {
-			matches = append(matches, card)
-		}
-	}
-	return matches
-}
-
-func (d *Deck) totalCopies(cardName string) int {
-	total := 0
-	for _, entry := range d.Cards {
-		if strings.EqualFold(entry.Name, cardName) {
-			total += entry.Count
-		}
-	}
-	return total
-}
-
-func (d *Deck) AddCard(reader *bufio.Reader, searchTerm string) bool {
-	results := d.SearchCards(searchTerm)
-	if len(results) == 0 {
-		fmt.Printf("%sNo valid card found matching '%s'.%s\n", colorRed, searchTerm, colorReset)
-		return false
-	}
-
-	var selected Card
-	if len(results) > 1 {
-		fmt.Printf("%s\nMultiple matches found:%s\n", colorCyan, colorReset)
-		for idx, card := range results {
-			fmt.Printf("  %d. %s (Set: %s, ID: %s)\n", idx+1, formatForDisplay(card.Name), formatForDisplay(card.Set), card.ID)
-		}
-		choiceStr, err := prompt(reader, fmt.Sprintf("%sEnter the number of the card you want to add: %s", colorWhite, colorReset))
-		if err != nil {
-			return false
-		}
-		choice, err := strconv.Atoi(choiceStr)
-		if err != nil || choice < 1 || choice > len(results) {
-			fmt.Printf("%sInvalid selection.%s\n", colorRed, colorReset)
-			return false
-		}
-		selected = results[choice-1]
-	} else {
-		selected = results[0]
-	}
-
-	cardName := formatForDisplay(selected.Name)
-	cardSet := formatForDisplay(selected.Set)
-
-	if d.totalCopies(cardName) >= 2 {
-		fmt.Printf("%sWarning: Already have 2 copies of %s (across all sets). Cannot add more.%s\n", colorYellow, cardName, colorReset)
-		return false
-	}
-
-	for idx := range d.Cards {
-		entry := &d.Cards[idx]
-		if strings.EqualFold(entry.Name, cardName) && strings.EqualFold(entry.Set, cardSet) {
-			if entry.Count >= 2 {
-				fmt.Printf("%sWarning: Already have 2 copies of %s from %s.%s\n", colorYellow, cardName, cardSet, colorReset)
-				return false
-			}
-			entry.Count++
-			if entry.Count == 2 {
-				fmt.Printf("%s%s from %s added. You now have 2 copies in this set.%s\n", colorGreen, cardName, cardSet, colorReset)
-			} else {
-				fmt.Printf("%s%s from %s added.%s\n", colorGreen, cardName, cardSet, colorReset)
-			}
-			return true
-		}
-	}
-
-	d.Cards = append(d.Cards, CardEntry{Name: cardName, Set: cardSet, Count: 1})
-	fmt.Printf("%s%s from %s added to your deck.%s\n", colorGreen, cardName, cardSet, colorReset)
-	return true
-}
-
-func (d *Deck) ViewDeck() {
-	if len(d.Cards) == 0 {
-		fmt.Printf("%sYour deck is empty.%s\n", colorYellow, colorReset)
-		return
-	}
-
-	fmt.Printf("%s\nDeck: %s%s\n", colorLightCyan, d.Name, colorReset)
-	for idx, entry := range d.Cards {
-		fmt.Printf("%s  %d. %s x %d from %s%s\n", colorLightCyan, idx+1, entry.Name, entry.Count, entry.Set, colorReset)
-	}
-}
-
-func (d *Deck) RemoveCard(index int) bool {
-	if index < 0 || index >= len(d.Cards) {
-		fmt.Printf("%sInvalid index. Nothing was removed.%s\n", colorRed, colorReset)
-		return false
-	}
-
-	entry := &d.Cards[index]
-	if entry.Count > 1 {
-		entry.Count--
-		fmt.Printf("%sOne copy of %s from %s removed. Now you have %d copy(ies).%s\n", colorGreen, entry.Name, entry.Set, entry.Count, colorReset)
-		return true
-	}
-
-	removed := d.Cards[index]
-	d.Cards = append(d.Cards[:index], d.Cards[index+1:]...)
-	fmt.Printf("%s%s from %s removed from your deck.%s\n", colorGreen, removed.Name, removed.Set, colorReset)
-	return true
-}
-
-func (d *Deck) RecordBattle(reader *bufio.Reader) {
-	outcome, err := prompt(reader, fmt.Sprintf("%sEnter battle outcome (W for win, L for loss): %s", colorWhite, colorReset))
-	if err != nil {
-		return
-	}
-	outcome = strings.ToUpper(strings.TrimSpace(outcome))
-	if outcome != "W" && outcome != "L" {
-		fmt.Printf("%sInvalid outcome. Use 'W' or 'L'.%s\n", colorRed, colorReset)
-		return
-	}
-
-	opponent, err := prompt(reader, fmt.Sprintf("%sEnter opponent deck details (or other metadata): %s", colorWhite, colorReset))
-	if err != nil {
-		return
-	}
-
-	record := BattleRecord{
-		Date:     time.Now().Format("2006-01-02 15:04:05"),
-		Result:   outcome,
-		Opponent: opponent,
-	}
-	d.BattleHistory = append(d.BattleHistory, record)
-	fmt.Printf("%sBattle record added for deck '%s'.%s\n", colorGreen, d.Name, colorReset)
-}
-
-func (d *Deck) ShowStatistics() {
-	totalBattles := len(d.BattleHistory)
-	if totalBattles == 0 {
-		fmt.Printf("%sNo battle records to show statistics.%s\n", colorYellow, colorReset)
-		return
-	}
-
-	wins := 0
-	loseMatchups := make(map[string]int)
-	for _, battle := range d.BattleHistory {
-		switch {
-		case strings.EqualFold(battle.Result, "W"):
-			wins++
-		case strings.EqualFold(battle.Result, "L"):
-			loseMatchups[battle.Opponent]++
-		}
-	}
-	losses := totalBattles - wins
-	winPercentage := (float64(wins) / float64(totalBattles)) * 100
-
-	fmt.Printf("%s\nBattle Statistics for '%s':%s\n", colorCyan, d.Name, colorReset)
-	fmt.Printf("%s  Total Battles: %d%s\n", colorCyan, totalBattles, colorReset)
-	fmt.Printf("%s  Wins: %d%s\n", colorCyan, wins, colorReset)
-	fmt.Printf("%s  Losses: %d%s\n", colorCyan, losses, colorReset)
-	fmt.Printf("%s  Win Percentage: %.2f%%%s\n", colorCyan, winPercentage, colorReset)
-
-	fmt.Printf("%s\nWin/Loss Graph:%s\n", colorBlue, colorReset)
-	fmt.Printf("%sWins  : %s%s\n", colorGreen, strings.Repeat("*", wins), colorReset)
-	fmt.Printf("%sLosses: %s%s\n", colorRed, strings.Repeat("*", losses), colorReset)
-
-	if len(loseMatchups) > 0 {
-		fmt.Printf("%s\nLoss Frequency by Opponent Deck:%s\n", colorLightMagenta, colorReset)
-		for opponent, count := range loseMatchups {
-			fmt.Printf("%s  %s: %d loss(es)%s\n", colorLightMagenta, opponent, count, colorReset)
-		}
-	}
-}
-
-func mainMenu(reader *bufio.Reader, deck *Deck) {
+func mainMenu(reader *bufio.Reader, deck *tcg.Deck) {
 	for {
 		fmt.Printf("%s\nMain Menu:%s\n", colorMagenta, colorReset)
 		fmt.Println("  0: List all available cards")
@@ -503,7 +185,15 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 
 		switch choice {
 		case "0":
-			deck.ListAvailableCards()
+			availableCards := deck.ListAvailableCards()
+			if len(availableCards) == 0 {
+				fmt.Printf("%sNo valid cards available.%s\n", colorRed, colorReset)
+			} else {
+				fmt.Printf("%s\nAvailable Cards:%s\n", colorCyan, colorReset)
+				for _, card := range availableCards {
+					fmt.Printf(" - %s (Set: %s, ID: %s)\n", formatForDisplay(card.Name), formatForDisplay(card.Set), card.ID)
+				}
+			}
 			next, err := prompt(reader, fmt.Sprintf("%s\nDo you want to add a card or go back to the main menu? (add/main): %s", colorMagenta, colorReset))
 			if err != nil {
 				continue
@@ -514,7 +204,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				if err != nil {
 					continue
 				}
-				deck.AddCard(reader, searchTerm)
+				addCard(reader, deck, searchTerm)
 			} else if next != "main" && next != "" {
 				fmt.Printf("%sInvalid choice. Going back to the main menu.%s\n", colorRed, colorReset)
 			}
@@ -523,7 +213,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 			if err != nil {
 				continue
 			}
-			deck.AddCard(reader, searchTerm)
+			addCard(reader, deck, searchTerm)
 			for {
 				cont, err := prompt(reader, fmt.Sprintf("%s\nDo you want to add another card? (yes/no): %s", colorMagenta, colorReset))
 				if err != nil {
@@ -535,7 +225,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 					if err != nil {
 						break
 					}
-					deck.AddCard(reader, searchTerm)
+					addCard(reader, deck, searchTerm)
 				} else if contLower == "no" {
 					break
 				} else {
@@ -544,7 +234,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 			}
 		case "2":
-			deck.ViewDeck()
+			viewDeck(deck)
 			action, err := prompt(reader, fmt.Sprintf("%s\nDo you want to remove a card or go back to the main menu? (rm/main): %s", colorMagenta, colorReset))
 			if err != nil {
 				continue
@@ -557,7 +247,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 				index, ok := promptForIndex(reader, len(deck.Cards))
 				if ok {
-					deck.RemoveCard(index)
+					removeCard(deck, index)
 				}
 			} else if action != "main" && action != "" {
 				fmt.Printf("%sInvalid choice. Going back to the main menu.%s\n", colorRed, colorReset)
@@ -567,10 +257,10 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				fmt.Printf("%sCannot remove from an empty deck.%s\n", colorRed, colorReset)
 				continue
 			}
-			deck.ViewDeck()
+			viewDeck(deck)
 			index, ok := promptForIndex(reader, len(deck.Cards))
 			if ok {
-				deck.RemoveCard(index)
+				removeCard(deck, index)
 			}
 			for len(deck.Cards) > 0 {
 				cont, err := prompt(reader, fmt.Sprintf("%s\nDo you want to remove another card? (yes/no): %s", colorMagenta, colorReset))
@@ -579,14 +269,14 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 				contLower := strings.ToLower(strings.TrimSpace(cont))
 				if contLower == "yes" {
-					deck.ViewDeck()
+					viewDeck(deck)
 					if len(deck.Cards) == 0 {
 						fmt.Printf("%sCannot remove from an empty deck.%s\n", colorRed, colorReset)
 						break
 					}
 					index, ok := promptForIndex(reader, len(deck.Cards))
 					if ok {
-						deck.RemoveCard(index)
+						removeCard(deck, index)
 					}
 				} else if contLower == "no" {
 					break
@@ -596,7 +286,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 			}
 		case "4":
-			deck.RecordBattle(reader)
+			recordBattle(reader, deck)
 			for {
 				next, err := prompt(reader, fmt.Sprintf("%s\nDo you want to record another battle or go back to the main menu? (add/main): %s", colorMagenta, colorReset))
 				if err != nil {
@@ -604,7 +294,7 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 				nextLower := strings.ToLower(strings.TrimSpace(next))
 				if nextLower == "add" {
-					deck.RecordBattle(reader)
+					recordBattle(reader, deck)
 				} else if nextLower == "main" {
 					break
 				} else {
@@ -613,11 +303,12 @@ func mainMenu(reader *bufio.Reader, deck *Deck) {
 				}
 			}
 		case "5":
-			deck.ShowStatistics()
+			showStatistics(deck)
 		case "6":
-			if err := deck.SaveDeck(); err != nil {
+			if err := deck.Save(); err != nil {
 				fmt.Printf("%sFailed to save deck: %v%s\n", colorRed, err, colorReset)
 			} else {
+				fmt.Printf("%sDeck '%s' saved successfully!%s\n", colorGreen, deck.Name, colorReset)
 				fmt.Printf("%s\nExiting. Your deck has been saved!%s\n", colorGreen, colorReset)
 			}
 			return
@@ -654,136 +345,146 @@ func promptForIndex(reader *bufio.Reader, length int) (int, bool) {
 	return index, true
 }
 
-func loadValidCards() []Card {
-	cards, err := fetchRemoteCards()
-	if err == nil {
-		fmt.Printf("%sLoaded latest card data from online database.%s\n", colorGreen, colorReset)
-		return cards
-	}
-
-	fmt.Printf("%sWarning: Could not fetch latest card data (%v). Using local cache.%s\n", colorYellow, err, colorReset)
-	localCards, localErr := loadLocalCards()
-	if localErr != nil {
-		fmt.Printf("%sError: valid_cards.json not found or invalid (%v).%s\n", colorRed, localErr, colorReset)
-		return nil
-	}
-	return localCards
-}
-
-func fetchRemoteCards() ([]Card, error) {
-	client := &http.Client{Timeout: 15 * time.Second}
-
-	var rawCards []remoteCard
-	if err := fetchJSON(client, cardsURL, &rawCards); err != nil {
-		return nil, err
-	}
-
-	var rawSets []remoteSet
-	if err := fetchJSON(client, setsURL, &rawSets); err != nil {
-		return nil, err
-	}
-
-	setMap := make(map[string]string)
-	for _, s := range rawSets {
-		if s.Code == "" {
-			continue
-		}
-		setMap[strings.ToLower(s.Code)] = pickLabel(s.Label, s.Code)
-	}
-
-	var cards []Card
-	for _, raw := range rawCards {
-		setCode := strings.TrimSpace(raw.Set)
-		if setCode == "" {
-			continue
-		}
-
-		numberStr := strings.TrimSpace(raw.Number.String())
-		if numberStr == "" {
-			continue
-		}
-		number, err := strconv.Atoi(numberStr)
-		if err != nil {
-			continue
-		}
-
-		name := strings.TrimSpace(pickLabel(raw.Label, ""))
-		if name == "" {
-			continue
-		}
-
-		setName := setMap[strings.ToLower(setCode)]
-		if setName == "" {
-			setName = setCode
-		}
-
-		cards = append(cards, Card{
-			Name: name,
-			Set:  fmt.Sprintf("%s (%s)", setName, setCode),
-			ID:   fmt.Sprintf("%s-%03d", strings.ToLower(setCode), number),
-		})
-	}
-
-	return cards, nil
-}
-
-func fetchJSON(client *http.Client, url string, target interface{}) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
-	}
-
-	decoder := json.NewDecoder(resp.Body)
-	decoder.UseNumber()
-	return decoder.Decode(target)
-}
-
-func pickLabel(label map[string]string, fallback string) string {
-	if label == nil {
-		return fallback
-	}
-	if eng, ok := label["eng"]; ok && strings.TrimSpace(eng) != "" {
-		return eng
-	}
-	if en, ok := label["en"]; ok && strings.TrimSpace(en) != "" {
-		return en
-	}
-	return fallback
-}
-
-func loadLocalCards() ([]Card, error) {
-	file, err := os.Open("valid_cards.json")
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var cards []Card
-	decoder := json.NewDecoder(file)
-	if err := decoder.Decode(&cards); err != nil {
-		return nil, err
-	}
-
-	for idx := range cards {
-		cards[idx].Name = strings.TrimSpace(cards[idx].Name)
-		cards[idx].Set = strings.TrimSpace(cards[idx].Set)
-		cards[idx].ID = strings.TrimSpace(cards[idx].ID)
-	}
-
-	return cards, nil
-}
-
 func formatForDisplay(value string) string {
 	return strings.TrimSpace(value)
+}
+
+func addCard(reader *bufio.Reader, deck *tcg.Deck, searchTerm string) {
+	results := deck.SearchCards(searchTerm)
+	if len(results) == 0 {
+		fmt.Printf("%sNo valid card found matching '%s'.%s\n", colorRed, searchTerm, colorReset)
+		return
+	}
+
+	var selected tcg.Card
+	if len(results) > 1 {
+		fmt.Printf("%s\nMultiple matches found:%s\n", colorCyan, colorReset)
+		for idx, card := range results {
+			fmt.Printf("  %d. %s (Set: %s, ID: %s)\n", idx+1, formatForDisplay(card.Name), formatForDisplay(card.Set), card.ID)
+		}
+		choiceStr, err := prompt(reader, fmt.Sprintf("%sEnter the number of the card you want to add: %s", colorWhite, colorReset))
+		if err != nil {
+			return
+		}
+		choice, err := strconv.Atoi(choiceStr)
+		if err != nil || choice < 1 || choice > len(results) {
+			fmt.Printf("%sInvalid selection.%s\n", colorRed, colorReset)
+			return
+		}
+		selected = results[choice-1]
+	} else {
+		selected = results[0]
+	}
+
+	result, err := deck.AddCardByID(selected.ID)
+	if err != nil {
+		fmt.Printf("%sFailed to add card: %v%s\n", colorRed, err, colorReset)
+		return
+	}
+
+	cardName := formatForDisplay(result.Card.Name)
+	cardSet := formatForDisplay(result.Card.Set)
+
+	if !result.Added {
+		if result.TotalCopies >= 2 {
+			fmt.Printf("%sWarning: Already have 2 copies of %s (across all sets). Cannot add more.%s\n", colorYellow, cardName, colorReset)
+			return
+		}
+		fmt.Printf("%sWarning: Already have 2 copies of %s from %s.%s\n", colorYellow, cardName, cardSet, colorReset)
+		return
+	}
+
+	if result.SetCopies == 2 {
+		fmt.Printf("%s%s from %s added. You now have 2 copies in this set.%s\n", colorGreen, cardName, cardSet, colorReset)
+	} else if result.SetCopies == 1 && result.TotalCopies == 1 {
+		fmt.Printf("%s%s from %s added to your deck.%s\n", colorGreen, cardName, cardSet, colorReset)
+	} else {
+		fmt.Printf("%s%s from %s added.%s\n", colorGreen, cardName, cardSet, colorReset)
+	}
+}
+
+func viewDeck(deck *tcg.Deck) {
+	if len(deck.Cards) == 0 {
+		fmt.Printf("%sYour deck is empty.%s\n", colorYellow, colorReset)
+		return
+	}
+
+	fmt.Printf("%s\nDeck: %s%s\n", colorLightCyan, deck.Name, colorReset)
+	for idx, entry := range deck.Cards {
+		fmt.Printf("%s  %d. %s x %d from %s%s\n", colorLightCyan, idx+1, entry.Name, entry.Count, entry.Set, colorReset)
+	}
+}
+
+func removeCard(deck *tcg.Deck, index int) {
+	entry, err := deck.RemoveCard(index)
+	if err != nil {
+		fmt.Printf("%sInvalid index. Nothing was removed.%s\n", colorRed, colorReset)
+		return
+	}
+	if entry.Count > 1 {
+		fmt.Printf("%sOne copy of %s from %s removed. Now you have %d copy(ies).%s\n", colorGreen, entry.Name, entry.Set, entry.Count, colorReset)
+		return
+	}
+	fmt.Printf("%s%s from %s removed from your deck.%s\n", colorGreen, entry.Name, entry.Set, colorReset)
+}
+
+func recordBattle(reader *bufio.Reader, deck *tcg.Deck) {
+	outcome, err := prompt(reader, fmt.Sprintf("%sEnter battle outcome (W for win, L for loss): %s", colorWhite, colorReset))
+	if err != nil {
+		return
+	}
+	opponent, err := prompt(reader, fmt.Sprintf("%sEnter opponent deck details (or other metadata): %s", colorWhite, colorReset))
+	if err != nil {
+		return
+	}
+	if err := deck.RecordBattle(outcome, opponent, time.Now()); err != nil {
+		fmt.Printf("%sInvalid outcome. Use 'W' or 'L'.%s\n", colorRed, colorReset)
+		return
+	}
+	fmt.Printf("%sBattle record added for deck '%s'.%s\n", colorGreen, deck.Name, colorReset)
+}
+
+func showStatistics(deck *tcg.Deck) {
+	stats := deck.Stats()
+	if stats.TotalBattles == 0 {
+		fmt.Printf("%sNo battle records to show statistics.%s\n", colorYellow, colorReset)
+		return
+	}
+
+	fmt.Printf("%s\nBattle Statistics for '%s':%s\n", colorCyan, deck.Name, colorReset)
+	fmt.Printf("%s  Total Battles: %d%s\n", colorCyan, stats.TotalBattles, colorReset)
+	fmt.Printf("%s  Wins: %d%s\n", colorCyan, stats.Wins, colorReset)
+	fmt.Printf("%s  Losses: %d%s\n", colorCyan, stats.Losses, colorReset)
+	fmt.Printf("%s  Win Percentage: %.2f%%%s\n", colorCyan, stats.WinPercentage, colorReset)
+
+	fmt.Printf("%s\nWin/Loss Graph:%s\n", colorBlue, colorReset)
+	fmt.Printf("%sWins  : %s%s\n", colorGreen, strings.Repeat("*", stats.Wins), colorReset)
+	fmt.Printf("%sLosses: %s%s\n", colorRed, strings.Repeat("*", stats.Losses), colorReset)
+
+	if len(stats.LossByOpponent) > 0 {
+		fmt.Printf("%s\nLoss Frequency by Opponent Deck:%s\n", colorLightMagenta, colorReset)
+		for opponent, count := range stats.LossByOpponent {
+			fmt.Printf("%s  %s: %d loss(es)%s\n", colorLightMagenta, opponent, count, colorReset)
+		}
+	}
+}
+
+func (m *DeckManager) handleDeckLoadMessages(deck *tcg.Deck) {
+	switch deck.CardsSource {
+	case tcg.CardsSourceRemote:
+		fmt.Printf("%sLoaded latest card data from online database.%s\n", colorGreen, colorReset)
+	case tcg.CardsSourceLocal:
+		if deck.CardsLoadError != nil {
+			fmt.Printf("%sWarning: Could not fetch latest card data (%v). Using local cache.%s\n", colorYellow, deck.CardsLoadError, colorReset)
+		}
+	}
+
+	switch deck.LoadStatus {
+	case tcg.DeckLoadNew:
+		fmt.Printf("%sDeck file '%s' not found. Starting new deck '%s'.%s\n", colorYellow, deck.FilePath, deck.Name, colorReset)
+	case tcg.DeckLoadReset:
+		fmt.Printf("%sError decoding %s. Starting with an empty deck.%s\n", colorRed, deck.FilePath, colorReset)
+	case tcg.DeckLoadLoaded:
+		fmt.Printf("%sDeck '%s' loaded from %s.%s\n", colorGreen, deck.Name, deck.FilePath, colorReset)
+	}
 }

--- a/tcg/cards.go
+++ b/tcg/cards.go
@@ -1,0 +1,150 @@
+package tcg
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	cardsURL = "https://raw.githubusercontent.com/flibustier/pokemon-tcg-pocket-database/main/dist/cards.json"
+	setsURL  = "https://raw.githubusercontent.com/flibustier/pokemon-tcg-pocket-database/main/dist/sets.json"
+)
+
+type remoteCard struct {
+	Set    string            `json:"set"`
+	Number json.Number       `json:"number"`
+	Label  map[string]string `json:"label"`
+}
+
+type remoteSet struct {
+	Code  string            `json:"code"`
+	Label map[string]string `json:"label"`
+}
+
+func LoadValidCards() ([]Card, CardsSource, error, error) {
+	cards, err := fetchRemoteCards()
+	if err == nil {
+		return cards, CardsSourceRemote, nil, nil
+	}
+
+	localCards, localErr := loadLocalCards()
+	if localErr != nil {
+		return nil, CardsSourceNone, nil, fmt.Errorf("remote error: %w; local error: %v", err, localErr)
+	}
+
+	return localCards, CardsSourceLocal, err, nil
+}
+
+func fetchRemoteCards() ([]Card, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+
+	var rawCards []remoteCard
+	if err := fetchJSON(client, cardsURL, &rawCards); err != nil {
+		return nil, err
+	}
+
+	var rawSets []remoteSet
+	if err := fetchJSON(client, setsURL, &rawSets); err != nil {
+		return nil, err
+	}
+
+	setMap := make(map[string]string)
+	for _, s := range rawSets {
+		if s.Code == "" {
+			continue
+		}
+		setMap[strings.ToLower(s.Code)] = pickLabel(s.Label, s.Code)
+	}
+
+	var cards []Card
+	for _, raw := range rawCards {
+		setCode := strings.TrimSpace(raw.Set)
+		if setCode == "" {
+			continue
+		}
+
+		number, err := parseRemoteCardNumber(raw.Number)
+		if err != nil {
+			continue
+		}
+
+		name := strings.TrimSpace(pickLabel(raw.Label, ""))
+		if name == "" {
+			continue
+		}
+
+		setName := setMap[strings.ToLower(setCode)]
+		if setName == "" {
+			setName = setCode
+		}
+
+		cards = append(cards, Card{
+			Name: name,
+			Set:  fmt.Sprintf("%s (%s)", setName, setCode),
+			ID:   fmt.Sprintf("%s-%03d", strings.ToLower(setCode), number),
+		})
+	}
+
+	return cards, nil
+}
+
+func fetchJSON(client *http.Client, url string, target interface{}) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	decoder.UseNumber()
+	return decoder.Decode(target)
+}
+
+func pickLabel(label map[string]string, fallback string) string {
+	if label == nil {
+		return fallback
+	}
+	if eng, ok := label["eng"]; ok && strings.TrimSpace(eng) != "" {
+		return eng
+	}
+	if en, ok := label["en"]; ok && strings.TrimSpace(en) != "" {
+		return en
+	}
+	return fallback
+}
+
+func loadLocalCards() ([]Card, error) {
+	file, err := os.Open("valid_cards.json")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var cards []Card
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&cards); err != nil {
+		return nil, err
+	}
+
+	for idx := range cards {
+		cards[idx].Name = strings.TrimSpace(cards[idx].Name)
+		cards[idx].Set = strings.TrimSpace(cards[idx].Set)
+		cards[idx].ID = strings.TrimSpace(cards[idx].ID)
+	}
+
+	return cards, nil
+}

--- a/tcg/deck.go
+++ b/tcg/deck.go
@@ -1,0 +1,265 @@
+package tcg
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Deck struct {
+	Name           string
+	FilePath       string
+	Cards          []CardEntry
+	BattleHistory  []BattleRecord
+	ValidCards     []Card
+	CardsSource    CardsSource
+	CardsLoadError error
+	LoadStatus     DeckLoadStatus
+}
+
+func NewDeck(name, filePath string) (*Deck, error) {
+	deck := &Deck{
+		Name:     name,
+		FilePath: filePath,
+	}
+
+	cards, source, warn, err := LoadValidCards()
+	if err != nil {
+		return nil, err
+	}
+	deck.ValidCards = cards
+	deck.CardsSource = source
+	deck.CardsLoadError = warn
+
+	status, err := deck.loadDeckFile()
+	if err != nil {
+		return nil, err
+	}
+	deck.LoadStatus = status
+
+	return deck, nil
+}
+
+func (d *Deck) loadDeckFile() (DeckLoadStatus, error) {
+	if _, err := os.Stat(d.FilePath); errors.Is(err, os.ErrNotExist) {
+		d.Cards = []CardEntry{}
+		d.BattleHistory = []BattleRecord{}
+		return DeckLoadNew, nil
+	} else if err != nil {
+		return DeckLoadReset, err
+	}
+
+	file, err := os.Open(d.FilePath)
+	if err != nil {
+		return DeckLoadReset, err
+	}
+	defer file.Close()
+
+	var data deckFileData
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&data); err != nil {
+		d.Cards = []CardEntry{}
+		d.BattleHistory = []BattleRecord{}
+		return DeckLoadReset, nil
+	}
+
+	d.Cards = data.Cards
+	d.BattleHistory = data.BattleHistory
+	return DeckLoadLoaded, nil
+}
+
+func (d *Deck) Save() error {
+	data := deckFileData{
+		Cards:         d.Cards,
+		BattleHistory: d.BattleHistory,
+	}
+
+	if err := os.MkdirAll(filepath.Dir(d.FilePath), 0o755); err != nil {
+		return err
+	}
+
+	file, err := os.Create(d.FilePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(&data)
+}
+
+func (d *Deck) ListAvailableCards() []Card {
+	return append([]Card(nil), d.ValidCards...)
+}
+
+func (d *Deck) SearchCards(term string) []Card {
+	normalized := strings.ToLower(strings.TrimSpace(term))
+	if normalized == "" {
+		return nil
+	}
+
+	var matches []Card
+	for _, card := range d.ValidCards {
+		name := strings.ToLower(card.Name)
+		set := strings.ToLower(card.Set)
+		if strings.Contains(name, normalized) || strings.Contains(set, normalized) {
+			matches = append(matches, card)
+		}
+	}
+	return matches
+}
+
+func (d *Deck) FindCardByID(cardID string) (Card, bool) {
+	needle := strings.ToLower(strings.TrimSpace(cardID))
+	if needle == "" {
+		return Card{}, false
+	}
+	for _, card := range d.ValidCards {
+		if strings.EqualFold(card.ID, needle) {
+			return card, true
+		}
+	}
+	return Card{}, false
+}
+
+func (d *Deck) AddCardByID(cardID string) (AddCardResult, error) {
+	card, ok := d.FindCardByID(cardID)
+	if !ok {
+		return AddCardResult{}, fmt.Errorf("card ID %q not found", cardID)
+	}
+
+	cardName := strings.TrimSpace(card.Name)
+	cardSet := strings.TrimSpace(card.Set)
+	totalCopies := d.totalCopies(cardName)
+	if totalCopies >= 2 {
+		return AddCardResult{
+			Card:        card,
+			Added:       false,
+			TotalCopies: totalCopies,
+			SetCopies:   d.setCopies(cardName, cardSet),
+		}, nil
+	}
+
+	for idx := range d.Cards {
+		entry := &d.Cards[idx]
+		if strings.EqualFold(entry.Name, cardName) && strings.EqualFold(entry.Set, cardSet) {
+			if entry.Count >= 2 {
+				return AddCardResult{
+					Card:        card,
+					Entry:       *entry,
+					Added:       false,
+					TotalCopies: totalCopies,
+					SetCopies:   entry.Count,
+				}, nil
+			}
+			entry.Count++
+			return AddCardResult{
+				Card:        card,
+				Entry:       *entry,
+				Added:       true,
+				TotalCopies: totalCopies + 1,
+				SetCopies:   entry.Count,
+			}, nil
+		}
+	}
+
+	entry := CardEntry{Name: cardName, Set: cardSet, Count: 1}
+	d.Cards = append(d.Cards, entry)
+	return AddCardResult{
+		Card:        card,
+		Entry:       entry,
+		Added:       true,
+		TotalCopies: totalCopies + 1,
+		SetCopies:   1,
+	}, nil
+}
+
+func (d *Deck) RemoveCard(index int) (CardEntry, error) {
+	if index < 0 || index >= len(d.Cards) {
+		return CardEntry{}, fmt.Errorf("index %d out of range", index)
+	}
+
+	entry := d.Cards[index]
+	if entry.Count > 1 {
+		d.Cards[index].Count--
+		entry.Count = d.Cards[index].Count
+		return entry, nil
+	}
+
+	d.Cards = append(d.Cards[:index], d.Cards[index+1:]...)
+	return entry, nil
+}
+
+func (d *Deck) RecordBattle(result, opponent string, now time.Time) error {
+	outcome := strings.ToUpper(strings.TrimSpace(result))
+	if outcome != "W" && outcome != "L" {
+		return fmt.Errorf("invalid outcome %q", result)
+	}
+
+	record := BattleRecord{
+		Date:     now.Format("2006-01-02 15:04:05"),
+		Result:   outcome,
+		Opponent: strings.TrimSpace(opponent),
+	}
+	if record.Opponent == "" {
+		record.Opponent = "Unknown"
+	}
+
+	d.BattleHistory = append(d.BattleHistory, record)
+	return nil
+}
+
+func (d *Deck) Stats() Stats {
+	stats := Stats{
+		LossByOpponent: make(map[string]int),
+	}
+	stats.TotalBattles = len(d.BattleHistory)
+	if stats.TotalBattles == 0 {
+		return stats
+	}
+
+	for _, battle := range d.BattleHistory {
+		switch {
+		case strings.EqualFold(battle.Result, "W"):
+			stats.Wins++
+		case strings.EqualFold(battle.Result, "L"):
+			stats.LossByOpponent[battle.Opponent]++
+		}
+	}
+	stats.Losses = stats.TotalBattles - stats.Wins
+	stats.WinPercentage = (float64(stats.Wins) / float64(stats.TotalBattles)) * 100
+	return stats
+}
+
+func (d *Deck) totalCopies(cardName string) int {
+	total := 0
+	for _, entry := range d.Cards {
+		if strings.EqualFold(entry.Name, cardName) {
+			total += entry.Count
+		}
+	}
+	return total
+}
+
+func (d *Deck) setCopies(cardName, cardSet string) int {
+	for _, entry := range d.Cards {
+		if strings.EqualFold(entry.Name, cardName) && strings.EqualFold(entry.Set, cardSet) {
+			return entry.Count
+		}
+	}
+	return 0
+}
+
+func parseRemoteCardNumber(number json.Number) (int, error) {
+	value := strings.TrimSpace(number.String())
+	if value == "" {
+		return 0, fmt.Errorf("empty card number")
+	}
+	return strconv.Atoi(value)
+}

--- a/tcg/manager.go
+++ b/tcg/manager.go
@@ -1,0 +1,55 @@
+package tcg
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type DeckManager struct {
+	DecksDir string
+}
+
+func NewDeckManager(decksDir string) (*DeckManager, error) {
+	if err := os.MkdirAll(decksDir, 0o755); err != nil {
+		return nil, err
+	}
+	return &DeckManager{DecksDir: decksDir}, nil
+}
+
+func (m *DeckManager) ListExistingDecks() ([]string, error) {
+	entries, err := os.ReadDir(m.DecksDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var decks []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".json") {
+			decks = append(decks, strings.TrimSuffix(name, ".json"))
+		}
+	}
+	sort.Strings(decks)
+	return decks, nil
+}
+
+func (m *DeckManager) CreateDeck(name string) (*Deck, error) {
+	deckFile := filepath.Join(m.DecksDir, name+".json")
+	if _, err := os.Stat(deckFile); err == nil {
+		return nil, os.ErrExist
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return NewDeck(name, deckFile)
+}
+
+func (m *DeckManager) LoadDeck(name string) (*Deck, error) {
+	deckFile := filepath.Join(m.DecksDir, name+".json")
+	return NewDeck(name, deckFile)
+}

--- a/tcg/stats.go
+++ b/tcg/stats.go
@@ -1,0 +1,9 @@
+package tcg
+
+type Stats struct {
+	TotalBattles   int
+	Wins           int
+	Losses         int
+	WinPercentage  float64
+	LossByOpponent map[string]int
+}

--- a/tcg/types.go
+++ b/tcg/types.go
@@ -1,0 +1,48 @@
+package tcg
+
+type Card struct {
+	Name string `json:"name"`
+	Set  string `json:"set"`
+	ID   string `json:"id"`
+}
+
+type CardEntry struct {
+	Name  string `json:"name"`
+	Set   string `json:"set"`
+	Count int    `json:"count"`
+}
+
+type BattleRecord struct {
+	Date     string `json:"date"`
+	Result   string `json:"result"`
+	Opponent string `json:"opponent"`
+}
+
+type deckFileData struct {
+	Cards         []CardEntry    `json:"cards"`
+	BattleHistory []BattleRecord `json:"battle_history"`
+}
+
+type DeckLoadStatus string
+
+type CardsSource string
+
+type AddCardResult struct {
+	Card        Card
+	Entry       CardEntry
+	Added       bool
+	TotalCopies int
+	SetCopies   int
+}
+
+const (
+	DeckLoadNew    DeckLoadStatus = "new"
+	DeckLoadLoaded DeckLoadStatus = "loaded"
+	DeckLoadReset  DeckLoadStatus = "reset"
+)
+
+const (
+	CardsSourceRemote CardsSource = "remote"
+	CardsSourceLocal  CardsSource = "local"
+	CardsSourceNone   CardsSource = "none"
+)


### PR DESCRIPTION
### Motivation
- Separate core deck/card/battle logic from the interactive CLI so the logic can be reused by other clients (e.g., mobile bindings). 
- Make deck loading, card lookup, add/remove, battle recording, and statistics available as a library to improve testability and reduce duplication. 
- Preserve the existing CLI user experience while delegating behavior to the library. 

### Description
- Add a new package `tcg` with `types.go`, `cards.go`, `deck.go`, `manager.go`, and `stats.go` that encapsulate card loading, deck management, and statistics operations. 
- Move card fetching (`LoadValidCards`/`fetchRemoteCards`/`loadLocalCards`), deck lifecycle (`NewDeck`, `Save`, `loadDeckFile`), and deck operations (`AddCardByID`, `RemoveCard`, `RecordBattle`, `Stats`) into the `tcg` package. 
- Update the CLI at `cmd/tcgcli/main.go` to delegate behavior to the `tcg` package and add small adapter helpers (e.g., `addCard`, `viewDeck`, `removeCard`, `recordBattle`, `showStatistics`, `handleDeckLoadMessages`) to preserve prompt text and output. 
- Run `gofmt` on modified files to normalize formatting. 

### Testing
- Ran `gofmt -w` on `cmd/tcgcli/main.go` and `tcg/*.go`, which completed successfully. 
- Attempted `go build ./cmd/tcgcli`, but the build run was interrupted/hung and was not completed. 
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962fdc270748326a632e3a4ee90c00a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates core functionality from the CLI into a reusable library and re-wires the CLI to call it.
> 
> - Introduces `tcg` package with `types.go`, `cards.go`, `deck.go`, `manager.go`, `stats.go` for card loading (`LoadValidCards`, remote/local fetch), deck lifecycle (`NewDeck`, `Save`), operations (`AddCardByID`, `RemoveCard`, `ListAvailableCards`, `SearchCards`, `RecordBattle`, `Stats`), and deck management (`NewDeckManager`, `CreateDeck`, `LoadDeck`).
> - Refactors `cmd/tcgcli/main.go` to use `tcg.Deck`/`tcg.DeckManager` and adds small helpers (`addCard`, `viewDeck`, `removeCard`, `recordBattle`, `showStatistics`, `handleDeckLoadMessages`); removes inline types, file/HTTP logic.
> - Preserves interactive prompts/output; adds load-source/status messaging via `CardsSource` and `DeckLoadStatus`.
> 
> Risk: broad refactor touching I/O and network code; potential behavior differences in card loading and deck persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2397bf1e4608007b30b1c5ea65119a2a71458152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->