### PR TITLE
Update iOS gomobile docs to use xcframework output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ This lets you generate an iOS framework that a Swift/SwiftUI app can call.
 go install golang.org/x/mobile/cmd/gomobile@latest
 gomobile init
 
-# Build an iOS framework from the mobile wrapper.
-gomobile bind -target=ios -o tcgcli.framework ./mobile
+# Build an iOS xcframework from the mobile wrapper.
+gomobile bind -target=ios -o tcgcli.xcframework ./mobile
 ```
 
-You can then import `tcgcli.framework` into an Xcode project and call the `tcgmobile.Manager`
+You can then import `tcgcli.xcframework` into an Xcode project and call the `tcgmobile.Manager`
 APIs to list decks, add cards, record battles, and pull JSON payloads for UI rendering.
 
 ## Sample Output

--- a/ios/SampleSwiftUI/README.md
+++ b/ios/SampleSwiftUI/README.md
@@ -5,6 +5,6 @@ They are **not** a full Xcode project. Copy them into a new SwiftUI app and upda
 module import if your framework is renamed.
 
 ## Notes
-- The `TCGClient` assumes the framework module name is `tcgcli` (from `tcgcli.framework`).
+- The `TCGClient` assumes the framework module name is `tcgcli` (from `tcgcli.xcframework`).
 - Update `decksDir` if you use a different application documents path.
 - JSON decoding uses lightweight Swift models that mirror the Go payloads.


### PR DESCRIPTION
### Motivation
- The `gomobile` tooling requires an `.xcframework` suffix for iOS framework output and using `.framework` causes build errors.
- Documentation and the SwiftUI sample referenced `tcgcli.framework`, which is inconsistent with the required output format.
- Aligning the docs prevents user confusion when running `gomobile bind` and importing the generated framework.

### Description
- Updated the `gomobile bind` example in `README.md` to output `tcgcli.xcframework` using `gomobile bind -target=ios -o tcgcli.xcframework ./mobile`.
- Replaced references to `tcgcli.framework` with `tcgcli.xcframework` in `README.md` and `ios/SampleSwiftUI/README.md`.
- This is a documentation-only change touching `README.md` and `ios/SampleSwiftUI/README.md`.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965e1e8fdd08326b5e4495b90f7ab9f)