### PR TITLE
Add battle results trend chart, spacing tweaks, and Catppuccin-Latte input fixes

### DIFF
--- a/cmd/tcgweb/web/assets/app.js
+++ b/cmd/tcgweb/web/assets/app.js
@@ -16,6 +16,8 @@ const connectionStatus = document.getElementById("connectionStatus");
 const themeSelect = document.getElementById("themeSelect");
 const backgroundUpload = document.getElementById("backgroundUpload");
 const clearBackground = document.getElementById("clearBackground");
+const battleChart = document.getElementById("battleChart");
+const battleChartNotice = document.getElementById("battleChartNotice");
 
 const THEME_KEY = "tcgcli-theme";
 const BG_KEY = "tcgcli-background";
@@ -176,6 +178,58 @@ function renderDeck(deck) {
   } else {
     lossList.textContent = "No loss breakdown yet.";
   }
+
+  renderBattleChart(deck);
+}
+
+function renderBattleChart(deck) {
+  if (!battleChart || !battleChartNotice) {
+    return;
+  }
+
+  const battles = deck?.battles || [];
+  battleChart.innerHTML = "";
+  if (battles.length === 0) {
+    battleChartNotice.textContent = "No battle results to chart yet.";
+    return;
+  }
+
+  battleChartNotice.textContent = "";
+  const width = 600;
+  const height = 220;
+  const padding = 28;
+  let wins = 0;
+  const points = battles.map((battle, index) => {
+    if (battle.result === "W") {
+      wins += 1;
+    }
+    const winRate = (wins / (index + 1)) * 100;
+    return { index, winRate };
+  });
+
+  const maxX = Math.max(points.length - 1, 1);
+  const xStep = (width - padding * 2) / maxX;
+  const yScale = (height - padding * 2) / 100;
+  const coords = points.map((point, index) => {
+    const x = padding + index * xStep;
+    const y = height - padding - point.winRate * yScale;
+    return { x, y };
+  });
+
+  const axis = `
+    <line class="chart-axis" x1="${padding}" y1="${padding}" x2="${padding}" y2="${height - padding}" />
+    <line class="chart-axis" x1="${padding}" y1="${height - padding}" x2="${width - padding}" y2="${height - padding}" />
+  `;
+
+  const pathData = coords
+    .map((point, index) => `${index === 0 ? "M" : "L"}${point.x},${point.y}`)
+    .join(" ");
+
+  const circles = coords
+    .map((point) => `<circle cx="${point.x}" cy="${point.y}" r="4" />`)
+    .join("");
+
+  battleChart.innerHTML = `${axis}<path d="${pathData}" />${circles}`;
 }
 
 async function loadDecks() {

--- a/cmd/tcgweb/web/assets/style.css
+++ b/cmd/tcgweb/web/assets/style.css
@@ -44,6 +44,17 @@
   --page-bg: linear-gradient(160deg, #f8f9fb 0%, #eff1f5 45%, #dce0e8 100%);
 }
 
+:root[data-theme="catppuccin-latte"] input,
+:root[data-theme="catppuccin-latte"] select {
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--text);
+  border-color: #c7cdda;
+}
+
+:root[data-theme="catppuccin-latte"] input::placeholder {
+  color: #7c7f93;
+}
+
 :root[data-theme="catppuccin-frappe"] {
   color-scheme: dark;
   --bg: #303446;
@@ -329,6 +340,10 @@ button.danger:hover {
   gap: 12px;
 }
 
+.card-results {
+  margin-top: 12px;
+}
+
 .card-item,
 .battle-item,
 .result-item {
@@ -373,6 +388,26 @@ button.danger:hover {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
+}
+
+.line-chart {
+  width: 100%;
+  height: 220px;
+}
+
+.line-chart path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 3;
+}
+
+.line-chart circle {
+  fill: var(--accent);
+}
+
+.line-chart .chart-axis {
+  stroke: var(--panel-border);
+  stroke-width: 1;
 }
 
 .stat {

--- a/cmd/tcgweb/web/assets/style.css
+++ b/cmd/tcgweb/web/assets/style.css
@@ -175,6 +175,51 @@
   --page-bg: linear-gradient(150deg, #fbf1c7 0%, #f2e5bc 50%, #d5c4a1 100%);
 }
 
+:root[data-theme="rose-pine"] {
+  color-scheme: dark;
+  --bg: #191724;
+  --panel: #1f1d2e;
+  --panel-border: #26233a;
+  --text: #e0def4;
+  --muted: #908caa;
+  --accent: #eb6f92;
+  --accent-dark: #9ccfd8;
+  --danger: #eb6f92;
+  --success: #31748f;
+  --shadow: rgba(25, 23, 36, 0.6);
+  --page-bg: linear-gradient(150deg, #191724 0%, #1f1d2e 50%, #26233a 100%);
+}
+
+:root[data-theme="rose-pine-dawn"] {
+  color-scheme: light;
+  --bg: #faf4ed;
+  --panel: #fffaf3;
+  --panel-border: #dfdad9;
+  --text: #575279;
+  --muted: #797593;
+  --accent: #d7827e;
+  --accent-dark: #286983;
+  --danger: #b4637a;
+  --success: #56949f;
+  --shadow: rgba(87, 82, 121, 0.15);
+  --page-bg: linear-gradient(150deg, #faf4ed 0%, #fffaf3 50%, #f2e9e1 100%);
+}
+
+:root[data-theme="rose-pine-moon"] {
+  color-scheme: dark;
+  --bg: #232136;
+  --panel: #2a273f;
+  --panel-border: #393552;
+  --text: #e0def4;
+  --muted: #908caa;
+  --accent: #c4a7e7;
+  --accent-dark: #9ccfd8;
+  --danger: #eb6f92;
+  --success: #3e8fb0;
+  --shadow: rgba(35, 33, 54, 0.6);
+  --page-bg: linear-gradient(150deg, #232136 0%, #2a273f 50%, #393552 100%);
+}
+
 * {
   box-sizing: border-box;
   margin: 0;

--- a/cmd/tcgweb/web/index.html
+++ b/cmd/tcgweb/web/index.html
@@ -89,6 +89,12 @@
       </div>
     </section>
 
+    <section class="panel panel--wide" aria-labelledby="battle-trend-title">
+      <h2 id="battle-trend-title">Battle Results Trend</h2>
+      <svg class="line-chart" id="battleChart" viewBox="0 0 600 220" role="img" aria-label="Line chart of battle win percentage over time"></svg>
+      <div class="notice" id="battleChartNotice"></div>
+    </section>
+
     <section class="panel" aria-labelledby="card-search-title">
       <h2 id="card-search-title">Find & Add Cards</h2>
       <form id="searchForm" class="stack">

--- a/cmd/tcgweb/web/index.html
+++ b/cmd/tcgweb/web/index.html
@@ -36,6 +36,11 @@
             <option value="tokyo-night-storm">Storm</option>
             <option value="tokyo-night-moon">Moon</option>
           </optgroup>
+          <optgroup label="Rose Pine">
+            <option value="rose-pine">Rose Pine</option>
+            <option value="rose-pine-dawn">Rose Pine Dawn</option>
+            <option value="rose-pine-moon">Rose Pine Moon</option>
+          </optgroup>
           <optgroup label="Gruvbox">
             <option value="gruvbox-dark">Dark</option>
             <option value="gruvbox-light">Light</option>


### PR DESCRIPTION
### Motivation
- Prevent card search results from visually crowding the search input by adding spacing above the results list.
- Provide a simple visual trend of deck battle outcomes so users can see win-rate progression over time.
- Ensure the `catppuccin-latte` theme keeps input fields readable by adjusting input/select background and placeholder color.

### Description
- Added a new `Battle Results Trend` panel with an `svg` (`#battleChart`) and notice (`#battleChartNotice`) to `cmd/tcgweb/web/index.html`.
- Implemented `renderBattleChart(deck)` in `cmd/tcgweb/web/assets/app.js` and call it from `renderDeck` to compute cumulative win-rate and draw an SVG path and points.
- Updated `cmd/tcgweb/web/assets/style.css` to add spacing for `.card-results`, add `.line-chart` SVG styles, and improve `:root[data-theme="catppuccin-latte"] input/select` and placeholder colors for readability.

### Testing
- Launched the web server using `go run ./cmd/tcgweb` which started successfully and served the updated UI.
- Ran an automated Playwright script that created a deck, recorded battles, performed a card search, and produced a screenshot artifact (`artifacts/battle-chart.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69668a0b2d048326bea4b2a49ba7578a)