### PR TITLE
Improve battle trend chart and split opponent details

### DIFF
--- a/cmd/tcgweb/web/assets/favicon.svg
+++ b/cmd/tcgweb/web/assets/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Pokéball with flame icon">
+  <defs>
+    <linearGradient id="flame" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f97316" />
+      <stop offset="0.5" stop-color="#ef4444" />
+      <stop offset="1" stop-color="#f59e0b" />
+    </linearGradient>
+    <linearGradient id="ballTop" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f87171" />
+      <stop offset="1" stop-color="#ef4444" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="#0f172a" />
+  <path d="M62 186c-18-22-10-54 12-72 16-13 26-30 27-51 20 12 32 33 28 56-2 14-10 26-22 35 10 4 22 3 34-4-2 26-17 45-40 54-16 6-28 2-39-18z" fill="url(#flame)" />
+  <circle cx="148" cy="140" r="68" fill="#0b1120" opacity="0.8" />
+  <circle cx="148" cy="140" r="60" fill="url(#ballTop)" />
+  <path d="M88 140h120c0 22-27 44-60 44s-60-22-60-44z" fill="#f8fafc" />
+  <rect x="88" y="130" width="120" height="20" fill="#111827" />
+  <circle cx="148" cy="140" r="22" fill="#111827" />
+  <circle cx="148" cy="140" r="12" fill="#f8fafc" />
+</svg>

--- a/cmd/tcgweb/web/assets/style.css
+++ b/cmd/tcgweb/web/assets/style.css
@@ -416,6 +416,12 @@ button.danger:hover {
   font-size: 0.85rem;
 }
 
+.battle-opponent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .card-item button,
 .result-item button {
   align-self: flex-start;
@@ -435,24 +441,89 @@ button.danger:hover {
   gap: 12px;
 }
 
-.line-chart {
-  width: 100%;
-  height: 220px;
+.panel--frosted {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.line-chart path {
+.chart-scroll {
+  margin-top: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+
+.line-chart {
+  width: 100%;
+  height: 260px;
+  display: block;
+}
+
+.line-chart .chart-path {
   fill: none;
-  stroke: var(--accent);
   stroke-width: 3;
 }
 
-.line-chart circle {
-  fill: var(--accent);
+.line-chart .chart-path.wins {
+  stroke: var(--success);
+}
+
+.line-chart .chart-path.losses {
+  stroke: var(--danger);
+}
+
+.line-chart .chart-point.wins {
+  fill: var(--success);
+}
+
+.line-chart .chart-point.losses {
+  fill: var(--danger);
 }
 
 .line-chart .chart-axis {
   stroke: var(--panel-border);
   stroke-width: 1;
+}
+
+.line-chart .chart-grid {
+  stroke: rgba(148, 163, 184, 0.2);
+  stroke-width: 1;
+}
+
+.line-chart .chart-label {
+  fill: var(--muted);
+  font-size: 0.7rem;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.legend-item.wins .legend-swatch {
+  background: var(--success);
+}
+
+.legend-item.losses .legend-swatch {
+  background: var(--danger);
 }
 
 .stat {
@@ -475,6 +546,15 @@ button.danger:hover {
 .loss-list {
   margin-top: 16px;
   color: var(--muted);
+}
+
+.result-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.85rem;
 }
 
 .helper {

--- a/cmd/tcgweb/web/index.html
+++ b/cmd/tcgweb/web/index.html
@@ -94,9 +94,15 @@
       </div>
     </section>
 
-    <section class="panel panel--wide" aria-labelledby="battle-trend-title">
+    <section class="panel panel--wide panel--frosted" aria-labelledby="battle-trend-title">
       <h2 id="battle-trend-title">Battle Results Trend</h2>
-      <svg class="line-chart" id="battleChart" viewBox="0 0 600 220" role="img" aria-label="Line chart of battle win percentage over time"></svg>
+      <div class="chart-scroll">
+        <svg class="line-chart" id="battleChart" viewBox="0 0 600 260" role="img" aria-label="Line chart of battle wins and losses over time"></svg>
+      </div>
+      <div class="chart-legend" aria-hidden="true">
+        <span class="legend-item wins"><span class="legend-swatch"></span>Wins</span>
+        <span class="legend-item losses"><span class="legend-swatch"></span>Losses</span>
+      </div>
       <div class="notice" id="battleChartNotice"></div>
     </section>
 
@@ -120,8 +126,10 @@
           <option value="W">Win</option>
           <option value="L">Loss</option>
         </select>
-        <label for="opponent">Opponent details</label>
-        <input id="opponent" name="opponent" type="text" placeholder="Opponent deck or notes" autocomplete="off" />
+        <label for="opponentDeck">Opponent deck name</label>
+        <input id="opponentDeck" name="opponentDeck" type="text" placeholder="Deck name" autocomplete="off" />
+        <label for="opponentDetails">Opponent details</label>
+        <input id="opponentDetails" name="opponentDetails" type="text" placeholder="Notes, pilot name, or context" autocomplete="off" />
         <button type="submit">Add battle</button>
       </form>
     </section>

--- a/cmd/tcgweb/web/index.html
+++ b/cmd/tcgweb/web/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>TCGCLI Web</title>
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
   <link rel="stylesheet" href="/assets/style.css" />
 </head>
 <body>

--- a/scripts/test_deck.json
+++ b/scripts/test_deck.json
@@ -1,0 +1,121 @@
+{
+  "cards": [
+    {
+      "name": "Pikachu ex",
+      "set": "Genetic Apex",
+      "count": 2
+    },
+    {
+      "name": "Zapdos",
+      "set": "Genetic Apex",
+      "count": 1
+    },
+    {
+      "name": "Raichu",
+      "set": "Genetic Apex",
+      "count": 1
+    }
+  ],
+  "battle_history": [
+    {
+      "date": "2026-01-01 09:05:00",
+      "result": "W",
+      "opponent": "Char Blaze — Regionals warmup"
+    },
+    {
+      "date": "2026-01-02 18:20:00",
+      "result": "L",
+      "opponent": "Snow Drift — Ladder climb"
+    },
+    {
+      "date": "2026-01-03 12:45:00",
+      "result": "W",
+      "opponent": "Garden Bloom — Testing session"
+    },
+    {
+      "date": "2026-01-04 20:10:00",
+      "result": "W",
+      "opponent": "Sky Surge — Best of 3"
+    },
+    {
+      "date": "2026-01-05 08:35:00",
+      "result": "L",
+      "opponent": "Rock Wall — League play"
+    },
+    {
+      "date": "2026-01-06 19:25:00",
+      "result": "W",
+      "opponent": "Moonlight — Friendly"
+    },
+    {
+      "date": "2026-01-07 14:15:00",
+      "result": "W",
+      "opponent": "Solar Flare — Stream match"
+    },
+    {
+      "date": "2026-01-08 21:05:00",
+      "result": "L",
+      "opponent": "Verdant Tide — Ladder session"
+    },
+    {
+      "date": "2026-01-09 10:40:00",
+      "result": "W",
+      "opponent": "Shadow Pulse — Scrimmage"
+    },
+    {
+      "date": "2026-01-10 17:30:00",
+      "result": "W",
+      "opponent": "Iron Crest — Local cup"
+    },
+    {
+      "date": "2026-01-11 13:50:00",
+      "result": "L",
+      "opponent": "Aqua Ring — Bracket"
+    },
+    {
+      "date": "2026-01-12 18:05:00",
+      "result": "W",
+      "opponent": "Crimson Gale — Practice"
+    },
+    {
+      "date": "2026-01-13 09:55:00",
+      "result": "W",
+      "opponent": "Thunder Line — Meta test"
+    },
+    {
+      "date": "2026-01-14 16:20:00",
+      "result": "L",
+      "opponent": "Frost Bloom — Ladder"
+    },
+    {
+      "date": "2026-01-15 11:15:00",
+      "result": "W",
+      "opponent": "Ember Wing — Friendly"
+    },
+    {
+      "date": "2026-01-16 19:40:00",
+      "result": "W",
+      "opponent": "Storm Echo — League"
+    },
+    {
+      "date": "2026-01-17 08:25:00",
+      "result": "L",
+      "opponent": "Leafbound — Event"
+    },
+    {
+      "date": "2026-01-18 15:05:00",
+      "result": "W",
+      "opponent": "Nightfall — Scrimmage"
+    },
+    {
+      "date": "2026-01-19 20:15:00",
+      "result": "W",
+      "opponent": "Volt Surge — Tournament"
+    },
+    {
+      "date": "2026-01-20 12:30:00",
+      "result": "L",
+      "opponent": "Terra Guard — Finals"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Make the battle trend visualization more informative and visually prominent by plotting Wins and Losses over time with clear markers.  
- Allow the chart to grow horizontally and be scrollable as battle entries increase so progression is easy to inspect.  
- Give the trend panel a frosted/translucent appearance to better fill the UI and improve legibility.  
- Capture opponent information with greater structure by splitting the open details into `opponentDeck` and `opponentDetails` fields.

### Description
- Redrew chart rendering in `cmd/tcgweb/web/assets/app.js` to plot separate wins and losses series, draw grid lines and date labels, compute a dynamic width, and set SVG `viewBox`/size for horizontal scrolling.  
- Added `formatBattleTimestamp` and `splitOpponent` helpers and updated battle recording to combine `opponentDeck` + `opponentDetails` into the stored `opponent` string, and updated UI rendering to show parsed opponent name/details.  
- Updated `cmd/tcgweb/web/index.html` to wrap the SVG in a scroll container, add a chart legend, and split the battle form inputs into `opponentDeck` and `opponentDetails`.  
- Added frosted panel styling, chart styling (paths, points, grid, labels), legend, and result meta styles in `cmd/tcgweb/web/assets/style.css`.

### Testing
- Launched the web server with `go run ./cmd/tcgweb` and the process started and listened on `:8080`.  
- Created a deck via `curl -X POST /api/decks` and received the expected deck JSON response.  
- Recorded multiple battles with a scripted `curl` loop that posted 10 battle records and verified the server accepted them.  
- Captured the updated UI with a Playwright script to produce a screenshot artifact showing the new chart and legend (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966901825d48326bc9b502047020c57)