### PR TITLE
Fix responsive panel layout for mobile views

### DIFF
--- a/cmd/tcgweb/web/assets/style.css
+++ b/cmd/tcgweb/web/assets/style.css
@@ -268,6 +268,7 @@ body {
 .app-shell {
   display: grid;
   gap: 20px;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .panel {
@@ -276,6 +277,7 @@ body {
   border-radius: 16px;
   padding: 20px;
   box-shadow: 0 20px 40px var(--shadow);
+  min-width: 0;
 }
 
 .panel-header {
@@ -453,6 +455,8 @@ button.danger:hover {
   margin-top: 12px;
   overflow-x: auto;
   padding-bottom: 8px;
+  max-width: 100%;
+  -webkit-overflow-scrolling: touch;
 }
 
 .line-chart {


### PR DESCRIPTION
### Motivation
- The app layout was overflowing on narrow screens after width changes, breaking mobile usability.
- Panels needed to be allowed to shrink inside the grid to prevent horizontal overflow.
- The battle results chart must retain horizontal scrolling while being touch-friendly on mobile.

### Description
- Constrain the main grid to a single responsive column by adding `grid-template-columns: minmax(0, 1fr)` to `.app-shell`.
- Allow panels to shrink by adding `min-width: 0` to `.panel` so children can properly truncate inside the grid.
- Improve the chart scroll container by adding `max-width: 100%` and `-webkit-overflow-scrolling: touch` to `.chart-scroll` to preserve horizontal scrolling and smooth touch behavior.
- Changes were made in `cmd/tcgweb/web/assets/style.css`.

### Testing
- Launched the web server with `go run ./cmd/tcgweb` and the server started successfully.
- Verified the index endpoint returned `HTTP/1.1 200 OK` using `curl -I http://localhost:8080` which succeeded.
- Captured a mobile viewport screenshot with a Playwright script which produced `artifacts/tcgweb-mobile.png` to validate the responsive layout, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696695bc875c8326a9eddf5b2d792152)